### PR TITLE
Add read_table function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@ pub fn write_file(data: String, table: &'static str) -> io::Result<()> {
 }
 
 pub fn read_table(table: &'static str) -> String {
-    let file = File::open(table).expect("no such file");
-    let buf = BufReader::new(file);
-    buf.lines().map(|l| l.expect("Could not parse line")).collect()
+    let file = File::open(table).expect("Table does not exist!");
+    let buf  = BufReader::new(file);
+    buf.lines().map(|l| l.expect("Table read failure!")).collect()
 }
 
 #[derive(RustcEncodable, Debug)]
@@ -25,10 +25,10 @@ struct TableData {
 
 #[test]
 fn it_reads_the_table() {
-    let mut x = TableData { test_string: String::new() };
+    let mut x     = TableData { test_string: String::new() };
     x.test_string = "test me".to_string();
-    let encoded = json::encode(&x).unwrap();
+    let encoded   = json::encode(&x).unwrap();
     write_file(encoded, "./foo");
-    let results  = read_table("./foo");
+    let results = read_table("./foo");
     assert_eq!(results, "{\"test_string\":\"test me\"}");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,6 @@ struct TableData {
 }
 
 #[test]
-fn it_works() {
-    let mut x = TableData { test_string: String::new() };
-    x.test_string = "test me".to_string();
-    let encoded = json::encode(&x).unwrap();
-    write_file(encoded, "./foo");
-}
-
-#[test]
 fn it_reads_the_table() {
     let mut x = TableData { test_string: String::new() };
     x.test_string = "test me".to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,18 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io;
 use rustc_serialize::json;
+use std::io::BufReader;
 
 pub fn write_file(data: String, table: &'static str) -> io::Result<()> {
     let mut buffer = try!(File::create(table.to_string()));
     try!(buffer.write_fmt(format_args!("{}", data)));
     Ok(())
+}
+
+pub fn read_table(table: &'static str) -> String {
+    let file = File::open(table).expect("no such file");
+    let buf = BufReader::new(file);
+    buf.lines().map(|l| l.expect("Could not parse line")).collect()
 }
 
 #[derive(RustcEncodable, Debug)]
@@ -22,4 +29,14 @@ fn it_works() {
     x.test_string = "test me".to_string();
     let encoded = json::encode(&x).unwrap();
     write_file(encoded, "./foo");
+}
+
+#[test]
+fn it_reads_the_table() {
+    let mut x = TableData { test_string: String::new() };
+    x.test_string = "test me".to_string();
+    let encoded = json::encode(&x).unwrap();
+    write_file(encoded, "./foo");
+    let results  = read_table("./foo");
+    assert_eq!(results, "{\"test_string\":\"test me\"}");
 }


### PR DESCRIPTION
Added read_table function
Can now prove that we can write a new file / table and read it's contents
Created corresponding it_reads_the_table test
Removed old it_works test
