### PR TITLE
Improve serializer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ use std::any::Any;
 
 mod sc; // sc == schema
 
-pub fn create_table<T: Serialize>(table: String, t: T) -> io::Result<()> {
-    let serialized = serde_json::to_string(&t).unwrap();
+pub fn create_table<P: AsRef<Path>, T: Serialize>(table: P, t: &T) -> io::Result<()> {
+    let serialized = serde_json::to_string(t).unwrap();
 
-    let db_table = format!("./db/{}", table);
+    let db_table = Path::new("./db").join(table);
     if Path::new(&db_table).exists() { return Ok(()) };
 
     let mut buffer = try!(File::create(db_table));
@@ -30,7 +30,7 @@ pub fn create_table<T: Serialize>(table: String, t: T) -> io::Result<()> {
 
 // let deserialized: sc::Coordinates = serde_json::from_str(&serialized).unwrap();
 
-pub fn read_table(table: &'static str) -> String {
+pub fn read_table<P: AsRef<Path>>(table: P) -> String {
     let file = File::open(table).expect("Table does not exist!");
     let buf  = BufReader::new(file);
     buf.lines().map(|l| l.expect("Table read failure!")).collect()
@@ -40,5 +40,5 @@ pub fn read_table(table: &'static str) -> String {
 fn it_can_take_any_struct() {
     let c = sc::Coordinates {x: 7, y: 90};
     let t_n = "test".to_string();
-    create_table(t_n, c);
+    create_table(t_n, &c);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,10 @@ pub fn create_table<P: AsRef<Path>, T: Serialize>(table: P, t: &T) -> io::Result
     let serialized = serde_json::to_string(t).unwrap();
 
     let db_table = Path::new("./db").join(table);
-    if Path::new(&db_table).exists() { return Ok(()) };
+    if db_table.exists() { return Ok(()) };
 
     let mut buffer = try!(File::create(db_table));
-    try!(buffer.write_fmt(format_args!("{}", serialized)));
+    try!(buffer.write_all(serialized.as_bytes()));
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 #![plugin(serde_macros)]
 
 extern crate serde_json;
+extern crate serde;
+
+use serde::ser::Serialize;
 
 use std::fs::File;
 use std::io::prelude::*;
@@ -13,7 +16,7 @@ use std::any::Any;
 
 mod sc; // sc == schema
 
-pub fn create_table<T: Any + Debug>(table: String, t: T) -> io::Result<()> {
+pub fn create_table<T: Serialize>(table: String, t: T) -> io::Result<()> {
     let serialized = serde_json::to_string(&t).unwrap();
 
     let db_table = format!("./db/{}", table);

--- a/src/sc/mod.rs
+++ b/src/sc/mod.rs
@@ -1,3 +1,6 @@
+use serde::ser::Serialize;
+use serde::de::Deserialize;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Coordinates {
     pub x: i32,


### PR DESCRIPTION
You may want to review these commits individually. The first makes `create_table` work with as many types as the underlying `serde_json::to_string` will, the others are obvious improvements for idiomatic code. There's more that can be done there.

It might be interesting to see if there's some interface in serde that can write the JSON string to a sink without ever materializing it in memory.
