### PR TITLE
Add functions to insert/read/delete json directly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 But to save Travis CI from building everytime, here is a Vagrantfile that you should setup!
 
-**Please change the `<PATH_TO_YOUR_LOCAL_FE_BUCKET_FORK_OR_PROJECT>` to your local project path!**
+**Please change the `<PATH_TO_YOUR_LOCAL_RUST_BUCKET_FORK_OR_PROJECT>` to your local project path!**
 
 ```
 $script = <<SCRIPT
@@ -22,13 +22,13 @@ $script = <<SCRIPT
   sudo /usr/sbin/update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
   sudo apt-get install git -y
   sudo curl -s https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
-  cd /home/vagrant/fe_bucket && cargo test && cargo bench
+  cd /home/vagrant/rust_bucket && cargo test && cargo bench
 SCRIPT
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.provision :shell, :inline => $script
-  config.vm.synced_folder "<PATH_TO_YOUR_LOCAL_FE_BUCKET_FORK_OR_PROJECT>", "/home/vagrant/fe_bucket"
+  config.vm.synced_folder "<PATH_TO_YOUR_LOCAL_FE_BUCKET_FORK_OR_PROJECT>", "/home/vagrant/rust_bucket"
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
   end

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,11 +1,11 @@
 Short version:
 
-The fe_bucket Project is dual-licensed under the terms of the Apache 2.0 and
+The rust_bucket Project is dual-licensed under the terms of the Apache 2.0 and
 MIT licenses.
 
 Longer:
 
-The Fe_Bucket Project is copyright 2016, The Fe_Bucket Project Developers.
+The Rust_Bucket Project is copyright 2016, The Rust_Bucket Project Developers.
 
 Licensed under the Apache License, Version 2.0
 <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "fe_bucket"
+name = "rust_bucket"
 version = "0.1.0"
-authors = ["Matt Pindell <pindell.m@gmail.com>", "Regis Boudinot <boudinot.regis@yahoo.com>"]
+authors = ["Matt Pindell <pindell.m@gmail.com>", "Regis Boudinot <boudinot.regis@yahoo.com>", "Alex Hill <alexander.d.hill.89@gmail.com>"]
 
 [dependencies]
 serde = "*"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2016 The Fe_Bucket Developers
+Copyright (c) 2016 The Rust_Bucket Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,7 +17,7 @@ use std::fmt::{self, Display, Formatter};
 use serde_json;
 
 // Bring the constructors of Error into scope so we can use them without an `Error::` incantation
-use self::Error::{Io, Serde, NoSuchTable};
+use self::Error::{Io, Serde, NoSuchTable, NoSuchKey};
 
 /// A Result alias often returned from methods that can fail for `fe_bucket` exclusive reasons.
 pub type Result<T> = std_result::Result<T, Error>;
@@ -35,7 +35,10 @@ pub enum Error {
     Serde(serde_json::Error),
 
     /// The user tried to read a table, but no such table exists.
-    NoSuchTable(String)
+    NoSuchTable(String),
+
+    /// The user tried to extract a key, but it didn't exist.
+    NoSuchKey
 }
 
 impl From<io::Error> for Error {
@@ -62,7 +65,8 @@ impl Display for Error {
                 e.fmt(f)
             },
             NoSuchTable(ref t) =>
-                write!(f, "Tried to open the table \"{}\", which does not exist.", t)
+                write!(f, "Tried to open the table \"{}\", which does not exist.", t),
+            NoSuchKey => write!(f, "Tried to retrieve a key which doesn't exist.")
         }
     }
 }
@@ -72,7 +76,8 @@ impl std_error::Error for Error {
         match *self {
             Io(ref e)      => e.description(),
             Serde(ref e)   => e.description(),
-            NoSuchTable(_) => "Tried to open a table that doesn't exist"
+            NoSuchTable(_) => "Tried to open a table that doesn't exist",
+            NoSuchKey => "Tried to retrieve a key which doesn't exist"
         }
     }
 
@@ -80,7 +85,8 @@ impl std_error::Error for Error {
         match *self {
             Io(ref e)      => Some(e),
             Serde(ref e)   => Some(e),
-            NoSuchTable(_) => None
+            NoSuchTable(_) => None,
+            NoSuchKey => None
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Fe_Bucket Project Developers. See the COPYRIGHT file at
+// Copyright 2016 The Rust_Bucket Project Developers. See the COPYRIGHT file at
 // the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
@@ -20,7 +20,7 @@ use serde_json;
 // Bring the constructors of Error into scope so we can use them without an `Error::` incantation
 use self::Error::{Io, Serde, ParseInt, NoSuchTable, NoSuchKey};
 
-/// A Result alias often returned from methods that can fail for `fe_bucket` exclusive reasons.
+/// A Result alias often returned from methods that can fail for `rust_bucket` exclusive reasons.
 pub type Result<T> = std_result::Result<T, Error>;
 
 /// Errors that can occur during `rust_bucket` operations
@@ -46,7 +46,7 @@ pub enum Error {
     NoSuchTable(String),
 
     /// The user tried to extract a key, but it didn't exist.
-    NoSuchKey
+    NoSuchKey,
 }
 
 impl From<io::Error> for Error {
@@ -73,18 +73,21 @@ impl Display for Error {
             Io(ref e) => {
                 try!(write!(f, "Error performing IO: "));
                 e.fmt(f)
-            },
+            }
             Serde(ref e) => {
                 try!(write!(f, "Error (de)serializing: "));
                 e.fmt(f)
-            },
+            }
             ParseInt(ref e) => {
                 try!(write!(f, "Error parsing an integer: "));
                 e.fmt(f)
-            },
-            NoSuchTable(ref t) =>
-                write!(f, "Tried to open the table \"{}\", which does not exist.", t),
-            NoSuchKey => write!(f, "Tried to retrieve a key which doesn't exist.")
+            }
+            NoSuchTable(ref t) => {
+                write!(f,
+                       "Tried to open the table \"{}\", which does not exist.",
+                       t)
+            }
+            NoSuchKey => write!(f, "Tried to retrieve a key which doesn't exist."),
         }
     }
 }
@@ -92,21 +95,21 @@ impl Display for Error {
 impl std_error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Io(ref e)      => e.description(),
-            Serde(ref e)   => e.description(),
+            Io(ref e) => e.description(),
+            Serde(ref e) => e.description(),
             ParseInt(ref e) => e.description(),
             NoSuchTable(_) => "Tried to open a table that doesn't exist",
-            NoSuchKey => "Tried to retrieve a key which doesn't exist"
+            NoSuchKey => "Tried to retrieve a key which doesn't exist",
         }
     }
 
     fn cause(&self) -> Option<&std_error::Error> {
         match *self {
-            Io(ref e)      => Some(e),
-            Serde(ref e)   => Some(e),
+            Io(ref e) => Some(e),
+            Serde(ref e) => Some(e),
             ParseInt(ref e) => Some(e),
             NoSuchTable(_) => None,
-            NoSuchKey => None
+            NoSuchKey => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,16 +160,16 @@ pub fn update_json(table: &str, json: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn read_json(table: &str, json: &str) -> Result<()> {
-    read_table(table);
+pub fn read_json(table: &str) -> Result<()> {
+    read_table(table).unwrap();
 
     Ok(())
 }
 
-pub fn delete_json(table: &str) -> Result <()> {
+pub fn delete_json(table: &str) -> Result<()> {
     let file = Path::new("./db").join(table);
     try!(fs::remove_file(file));
-    
+
     Ok(())
 }
 
@@ -309,7 +309,8 @@ mod tests {
 
         let jtable = json_table::<sc::Coordinates>;
         let table = jtable("test6");
-        assert_eq!(table, "{\"table\":\"test6\",\"next_id\":\"1\",\"records\":{\"0\":{}}}");
+        assert_eq!(table,
+                   "{\"table\":\"test6\",\"next_id\":\"1\",\"records\":{\"0\":{}}}");
 
         drop_table("test6").unwrap();
     }
@@ -358,5 +359,14 @@ mod tests {
     fn bench_find(b: &mut Bencher) {
         let a = find::<sc::Coordinates>;
         b.iter(|| a("test2", "0"));
+    }
+
+    #[bench]
+    fn bench_store_update_read_and_delete_json(b: &mut Bencher) {
+        b.iter(|| store_json("test7", "{\"x\":42,\"y\":9000}}}").unwrap());
+
+        update_json("test7", "{\"x\":45,\"y\":9876}}}").unwrap();
+        read_json("test7").unwrap();
+        delete_json("test7").unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,8 +126,8 @@ pub fn json_table_records<T: Serialize + Deserialize>(table: &str) -> Result<Str
     serde_json::to_string(&records).map_err(Error::from)
 }
 
-pub fn json_table<T: Serialize + Deserialize>(table: &str) -> String {
-    read_table(table).unwrap_or(String::from("\'failed to get table\'"))
+pub fn json_table<T: Serialize + Deserialize>(table: &str) -> Result<String> {
+    read_table(table).map_err(Error::from)
 }
 
 pub fn store_json(table: &str, json: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn drop_table(table: &str) -> io::Result<()> {
 
 pub fn append_records<T: Serialize + Deserialize>(table: &str, t: T) -> Result<()> {
     let mut data = try!(get_table(table));
-    let increased_next_id = data.next_id.parse::<i32>().unwrap();
+    let increased_next_id = try!(data.next_id.parse::<i32>());
     let new_id = increased_next_id + 1;
 
     data.records.insert(increased_next_id.to_string(), t);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Fe_Bucket Project Developers. See the COPYRIGHT file at
+// Copyright 2016 The Rust_Bucket Project Developers. See the COPYRIGHT file at
 // the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,27 +332,27 @@ mod tests {
     fn bench_json_table(b: &mut Bencher) {
         let a = json_table::<sc::Coordinates>;
 
-        b.iter(|| a("test2"));
+        b.iter(|| a("test2").unwrap());
     }
 
     #[bench]
     fn bench_json_table_records(b: &mut Bencher) {
         let a = json_table_records::<sc::Coordinates>;
 
-        b.iter(|| a("test2"));
+        b.iter(|| a("test2").unwrap());
     }
 
     #[bench]
     fn bench_json_find(b: &mut Bencher) {
         let a = json_find::<sc::Coordinates>;
 
-        b.iter(|| a("test2", "0"));
+        b.iter(|| a("test2", "0").unwrap());
     }
 
     #[bench]
     fn bench_find(b: &mut Bencher) {
         let a = find::<sc::Coordinates>;
-        b.iter(|| a("test2", "0"));
+        b.iter(|| a("test2", "0").unwrap());
     }
 
     #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,9 +113,7 @@ pub fn find<T: Serialize + Deserialize>(table: &str, id: &str) -> T {
 pub fn delete<T: Serialize + Deserialize>(table: &str, id: &str) -> Result<()> {
     let mut current_table: HashMap<String, T> = get_table_records(table);
     current_table.remove(id);
-    update_table(table, &current_table).unwrap();
-
-    Ok(())
+    update_table(table, &current_table)
 }
 
 pub fn json_find<T: Serialize + Deserialize>(table: &str, id: &str) -> String {
@@ -160,10 +158,8 @@ pub fn update_json(table: &str, json: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn read_json(table: &str) -> Result<()> {
-    read_table(table).unwrap();
-
-    Ok(())
+pub fn read_json(table: &str) -> Result<(String)> {
+    read_table(table)
 }
 
 pub fn delete_json(table: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ pub fn read_table(table: &str) -> Result<String> {
 pub fn drop_table(table: &str) -> io::Result<()> {
     let t = Path::new("./db").join(table);
     try!(fs::remove_file(t));
+
     Ok(())
 }
 
@@ -119,17 +120,17 @@ pub fn delete<T: Serialize + Deserialize>(table: &str, id: &str) -> Result<()> {
 pub fn json_find<T: Serialize + Deserialize>(table: &str, id: &str) -> String {
     let incoming_record: T = find(table, id);
     let json_record = serde_json::to_string(&incoming_record);
-    json_record.unwrap()
+    json_record.unwrap_or(String::from("\'failed to get table\'"))
 }
 
 pub fn json_table_records<T: Serialize + Deserialize>(table: &str) -> String {
     let records: HashMap<String, T> = get_table_records(table);
     let json_records = serde_json::to_string(&records);
-    json_records.unwrap()
+    json_records.unwrap_or(String::from("\'failed to get records\'"))
 }
 
 pub fn json_table<T: Serialize + Deserialize>(table: &str) -> String {
-    read_table(table).unwrap()
+    read_table(table).unwrap_or(String::from("\'failed to get table\'"))
 }
 
 pub fn store_json(table: &str, json: &str) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,45 @@ pub fn json_table<T: Serialize + Deserialize>(table: &str) -> String {
     read_table(table).unwrap()
 }
 
+pub fn store_json(table: &str, json: &str) -> Result<()> {
+    try!(create_db_dir());
+
+    let db_table = Path::new("./db").join(table);
+
+    if db_table.exists() {
+        return Ok(());
+    }
+
+    let mut buffer = try!(File::create(db_table));
+    try!(buffer.write_all(json.as_bytes()));
+
+    Ok(())
+}
+
+pub fn update_json(table: &str, json: &str) -> Result<()> {
+    try!(create_db_dir());
+
+    let db_table = Path::new("./db").join(table);
+
+    let mut buffer = try!(File::create(db_table));
+    try!(buffer.write_all(json.as_bytes()));
+
+    Ok(())
+}
+
+pub fn read_json(table: &str, json: &str) -> Result<()> {
+    read_table(table);
+
+    Ok(())
+}
+
+pub fn delete_json(table: &str) -> Result <()> {
+    let file = Path::new("./db").join(table);
+    try!(fs::remove_file(file));
+    
+    Ok(())
+}
+
 // Private functions ******************************************************************************
 
 fn upgrade_table<T: Serialize>(table: &str, t: &T) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ mod tests {
         create_table("test5", &a).unwrap();
         assert_eq!(a, find("test5", "0").unwrap());
 
-        let b: String = json_table::<sc::Coordinates>("test5");
+        let b: String = json_table::<sc::Coordinates>("test5").unwrap();
         let c: String = json_table_records::<sc::Coordinates>("test5").unwrap();
         let d: String = json_find::<sc::Coordinates>("test5", "0").unwrap();
 
@@ -302,7 +302,7 @@ mod tests {
         del("test6", "0").unwrap();
 
         let jtable = json_table::<sc::Coordinates>;
-        let table = jtable("test6");
+        let table = jtable("test6").unwrap();
         assert_eq!(table,
                    "{\"table\":\"test6\",\"next_id\":\"1\",\"records\":{\"0\":{}}}");
 


### PR DESCRIPTION
Pending tests.

Allows for super-simple JSON storage and extraction.

``` rust
pub fn store_json(table: &str, json: &str) -> Result<()> {
    try!(create_db_dir());

    let db_table = Path::new("./db").join(table);

    if db_table.exists() {
        return Ok(());
    }

    let mut buffer = try!(File::create(db_table));
    try!(buffer.write_all(json.as_bytes()));

    Ok(())
}

pub fn update_json(table: &str, json: &str) -> Result<()> {
    try!(create_db_dir());

    let db_table = Path::new("./db").join(table);

    let mut buffer = try!(File::create(db_table));
    try!(buffer.write_all(json.as_bytes()));

    Ok(())
}

pub fn read_json(table: &str, json: &str) -> Result<()> {
    read_table(table);

    Ok(())
}

pub fn delete_json(table: &str) -> Result <()> {
    let file = Path::new("./db").join(table);
    try!(fs::remove_file(file));

    Ok(())
}
```
