### PR TITLE
Add create_empty_table function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,20 @@ mod tests {
     }
 
     #[test]
+    fn it_can_create_and_drop_an_empty_table() {
+        let table_name = format!("empty");
+
+        create_empty_table(&*table_name).unwrap();
+
+        let contents: String = read_table(&*table_name).unwrap();
+        let expected = "";
+
+        assert_eq!(expected, contents);
+
+        drop_table(&*table_name).unwrap();
+    }
+
+    #[test]
     fn it_can_get_and_find() {
         let a = sc::Coordinates { x: 42, y: 9000 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,20 @@ pub fn create_table<T: Serialize>(table: &str, t: &T) -> Result<()> {
     Ok(())
 }
 
+pub fn create_empty_table(table: &str) -> Result<()> {
+    try!(create_db_dir());
+
+    let db_table = Path::new("./db").join(table);
+
+    if db_table.exists() {
+        return Ok(());
+    }
+
+    let mut buffer = try!(File::create(db_table));
+
+    Ok(())
+}
+
 pub fn read_table(table: &str) -> Result<String> {
     let db_table = Path::new("./db").join(table);
     let mut file = match File::open(db_table) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub fn create_empty_table<T: Serialize>(table: &str) -> Result<()> {
 
     let data = Data {
         table: table.to_string(),
-        next_id: "1".to_string(),
+        next_id: "0".to_string(),
         records: record,
     };
 
@@ -260,7 +260,7 @@ mod tests {
         create_empty_table::<sc::Coordinates>(&*table_name).unwrap();
 
         let contents: String = read_table(&*table_name).unwrap();
-        let expected = "{\"table\":\"empty\",\"next_id\":\"1\",\"records\":{}}";
+        let expected = "{\"table\":\"empty\",\"next_id\":\"0\",\"records\":{}}";
 
         assert_eq!(expected, contents);
 


### PR DESCRIPTION
Basic function to create an empty table: `create_empty_table`
Tested with `it_can_create_and_drop_an_empty_table`
